### PR TITLE
[fix] remove broken link for glossary as it was moved to architecture

### DIFF
--- a/source/v3.md
+++ b/source/v3.md
@@ -28,7 +28,6 @@ For now, most of the documentation of the new stack is available in [the reposit
 
 ## Architecture
 
-- [Glossary](https://github.com/cozy/cozy-stack/blob/master/docs/glossary.md)
 - [General overview](https://github.com/cozy/cozy-stack/blob/master/docs/architecture.md)
 - [Applications Management](https://github.com/cozy/cozy-stack/blob/master/docs/apps.md)
 - [Authentication & Oauth](https://github.com/cozy/cozy-stack/blob/master/docs/auth.md)


### PR DESCRIPTION
Glossary.md was moved to [Architecture](https://github.com/cozy/cozy-stack/blob/master/docs/architecture.md) in http://github.com/cozy/cozy-stack/commit/aa8e364b0f275e2c84b1e413e262d544759f6641